### PR TITLE
Fix invalid argument to mrand.Intn on 32-bit systems

### DIFF
--- a/internal/simulator/simulator.go
+++ b/internal/simulator/simulator.go
@@ -217,7 +217,7 @@ func (s *simulation) runSimulation() error {
 			simulator.WithDevEUI(devEUI),
 			simulator.WithAppKey(appKey),
 			simulator.WithUplinkInterval(s.uplinkInterval),
-			simulator.WithOTAADelay(time.Duration(mrand.Intn(int(s.activationTime)))),
+			simulator.WithOTAADelay(time.Duration(mrand.Int63n(int64(s.activationTime)))),
 			simulator.WithUplinkPayload(false, s.fPort, s.payload),
 			simulator.WithGateways(gws),
 			simulator.WithUplinkTXInfo(gw.UplinkTXInfo{


### PR DESCRIPTION
The int type are 32 bits wide on 32-bit systems in golang. Converting
time.Duration to int on a 32-bit systems with the 'int(s.activationTime)'
may cause the overflow. For example, for a duration '1m' (1 minute) the
conversion to int should result in 600000000000000 (ns), exceeding 2^32.
To avoid this conversion problem on 32-bit systems, we need to convert
time.Duration to int64 type and use mrand.Int63n instead of mrand.Intn.

Fixes: #4