### PR TITLE
Make timeout for connecting to the API server adjustable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ log_level=4
   # Set this to true when the endpoint is not using TLS.
   insecure=true
 
+  # Timeout.
+  # 
+  # This determines the maximum amount of time connecting to the API may take.
+  # You may increase the timeout if the context deadline exceeded.
+  timeout="2s"
 
   # MQTT integration configuration.
   #

--- a/cmd/chirpstack-simulator/cmd/configfile.go
+++ b/cmd/chirpstack-simulator/cmd/configfile.go
@@ -49,6 +49,11 @@ log_level={{ .General.LogLevel }}
   # Set this to true when the endpoint is not using TLS.
   insecure={{ .ApplicationServer.API.Insecure }}
 
+  # Timeout.
+  # 
+  # This determines the maximum amount of time connecting to the API may take.
+  # You may increase the timeout if the context deadline exceeded.
+  timeout="{{ .ApplicationServer.API.Timeout }}"
 
   # MQTT integration configuration.
   #

--- a/cmd/chirpstack-simulator/cmd/root.go
+++ b/cmd/chirpstack-simulator/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"io/ioutil"
+	"time"
 
 	"github.com/brocaar/chirpstack-simulator/internal/config"
 	log "github.com/sirupsen/logrus"
@@ -39,6 +40,7 @@ func init() {
 	viper.BindPFlag("general.log_level", rootCmd.PersistentFlags().Lookup("log-level"))
 
 	viper.SetDefault("application_server.api.server", "127.0.0.1:8080")
+	viper.SetDefault("application_server.api.timeout", 1*time.Second)
 	viper.SetDefault("application_server.integration.mqtt.server", "tcp://127.0.0.1:1883")
 	viper.SetDefault("network_server.gateway.backend.mqtt.server", "tcp://127.0.0.1:1883")
 	viper.SetDefault("prometheus.bind", "0.0.0.0:9000")

--- a/internal/as/api.go
+++ b/internal/as/api.go
@@ -3,7 +3,6 @@ package as
 import (
 	"context"
 	"crypto/tls"
-	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/pkg/errors"
@@ -40,6 +39,7 @@ func Setup(c config.Config) error {
 	log.WithFields(log.Fields{
 		"server":   conf.API.Server,
 		"insecure": conf.API.Insecure,
+		"timeout":  conf.API.Timeout,
 	}).Info("as: connecting api client")
 
 	dialOpts := []grpc.DialOption{
@@ -53,7 +53,7 @@ func Setup(c config.Config) error {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), conf.API.Timeout)
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, conf.API.Server, dialOpts...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,9 +15,10 @@ type Config struct {
 
 	ApplicationServer struct {
 		API struct {
-			JWTToken string `mapstructure:"jwt_token"`
-			Server   string `mapstructure:"server"`
-			Insecure bool   `mapstructure:"insecure"`
+			JWTToken string        `mapstructure:"jwt_token"`
+			Server   string        `mapstructure:"server"`
+			Insecure bool          `mapstructure:"insecure"`
+			Timeout  time.Duration `mapstructure:"timeout"`
 		} `mapstructure:"api"`
 
 		Integration struct {


### PR DESCRIPTION
Ahoy,

since it could be that the connection to the API server takes longer than one second (leading to a `grpc dial error: context deadline exceeded`) I made the timeout for the provided context adjustable.
The default value is now set to one second, which was previously set as mandatory.

Warm regards,
Malte