### PR TITLE
Change NetworkServer to ChirpStack in config template

### DIFF
--- a/cmd/chirpstack-simulator/cmd/configfile.go
+++ b/cmd/chirpstack-simulator/cmd/configfile.go
@@ -65,13 +65,13 @@ const configTemplate = `[general]
   [chirpstack.gateway.backend.mqtt]
 
     # MQTT server.
-    server="{{ .NetworkServer.Gateway.Backend.MQTT.Server }}"
+    server="{{ .ChirpStack.Gateway.Backend.MQTT.Server }}"
 
     # Username.
-    username="{{ .NetworkServer.Gateway.Backend.MQTT.Username }}"
+    username="{{ .ChirpStack.Gateway.Backend.MQTT.Username }}"
 
     # Password.
-    password="{{ .NetworkServer.Gateway.Backend.MQTT.Password }}"
+    password="{{ .ChirpStack.Gateway.Backend.MQTT.Password }}"
 
 
 # Simulator configuration.


### PR DESCRIPTION
Fix build error: "can't evaluate field NetworkServer in type *config.Config" 
